### PR TITLE
Additional parameters for Bing reverse method

### DIFF
--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -164,7 +164,14 @@ class Bing(Geocoder):
             exactly_one
         )
 
-    def reverse(self, query, exactly_one=True, timeout=None):
+    def reverse(
+            self,
+            query,
+            exactly_one=True,
+            timeout=None,
+            culture=None,
+            include_country_code=False
+        ):  # pylint: disable=W0221
         """
         Reverse geocode a point.
 
@@ -181,9 +188,21 @@ class Bing(Geocoder):
             only, the value set during the geocoder's initialization.
 
             .. versionadded:: 0.97
+
+        :param string culture: Affects the language of the response,
+            must be a two-letter country code.
+
+        :param boolean include_country_code: Sets whether to include the
+            two-letter ISO code of the country in the response (field name
+            'countryRegionIso2').
         """
         point = self._coerce_point_to_string(query)
         params = {'key': self.api_key}
+        if culture:
+            params['culture'] = culture
+        if include_country_code:
+            params['include'] = 'ciso2'  # the only acceptable value
+
         url = "%s/%s?%s" % (
             self.api, point, urlencode(params))
 

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -73,6 +73,48 @@ class BingTestCase(GeocoderTestBase):
             self.assertAlmostEqual(res.latitude, 40.753, delta=self.delta)
             self.assertAlmostEqual(res.longitude, -73.984, delta=self.delta)
 
+    def test_reverse_with_culture_de(self):
+        """
+        Bing.reverse using point and culture parameter to get a non english response
+        """
+        res = self._make_request(
+            self.geocoder.reverse,
+            Point(40.753898, -73.985071),
+            culture="DE"
+        )
+        if res is None:
+            unittest.SkipTest("Bing sometimes returns no result")
+        else:
+            self.assertIn("Vereinigte Staaten von Amerika", res.address)
+
+    def test_reverse_with_culture_en(self):
+        """
+        Bing.reverse using point and culture parameter to get an english response
+        """
+        res = self._make_request(
+            self.geocoder.reverse,
+            Point(40.753898, -73.985071),
+            culture="EN"
+        )
+        if res is None:
+            unittest.SkipTest("Bing sometimes returns no result")
+        else:
+            self.assertIn("United States", res.address)
+
+    def test_reverse_with_include_country_code(self):
+        """
+        Bing.reverse using point and include country-code in the response
+        """
+        res = self._make_request(
+            self.geocoder.reverse,
+            Point(40.753898, -73.985071),
+            include_country_code=True
+        )
+        if res is None:
+            unittest.SkipTest("Bing sometimes returns no result")
+        else:
+            self.assertEqual(res.raw["address"].get("countryRegionIso2", 'missing'), 'US')
+
     def test_user_location(self):
         """
         Bing.geocode using `user_location`


### PR DESCRIPTION
Optional parameters that influence the form of
the response such as culture (sets the language
of the response) or whether to include the
neighborhood or the two-letter ISO code of the
country.
